### PR TITLE
docs: document mapping concept, CLI commands, and updated onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ method = "oauth"                    # "oauth" (default) or "password"
 poll_interval = 60                  # seconds between full syncs
 batch_window = 5                    # reserved — not yet active
 socket_path = "/tmp/tickticksync.sock"
-queue_path = "/home/you/.local/share/tickticksync/hook_queue.json"  # use absolute path; ~ is not expanded
+queue_path = "/home/you/.local/share/tickticksync/hook_queue.json"  # use absolute path; ~ is not expanded (update after init)
 
 [mapping]
 default_project = "inbox"           # reserved — not yet active
@@ -160,7 +160,7 @@ taskwarrior = "personal"
 | `[sync]` | `poll_interval` | Seconds between daemon sync cycles |
 | `[sync]` | `batch_window` | Seconds to batch hook events before syncing (reserved — not yet active) |
 | `[sync]` | `socket_path` | Unix socket path for hook-to-daemon communication |
-| `[sync]` | `queue_path` | File path for queued events when daemon is down (use absolute path; `~` is not expanded) |
+| `[sync]` | `queue_path` | File path for queued events when daemon is down (use absolute path; `~` is not expanded — update after `init`) |
 | `[mapping]` | `default_project` | Fallback TickTick project for unmapped TW tasks (reserved — not yet active) |
 | `[[mapping.projects]]` | `ticktick`, `taskwarrior` | One-to-one project mapping pair |
 


### PR DESCRIPTION
## Summary

- Rewrite Setup section to describe the interactive 4-step init wizard
- Add `### Managing mappings` subsection to Usage with `list/add/remove` commands and example output
- Add `## Mapping` concept section explaining one-to-one mappings and unmapped-project behavior
- Expand Configuration section with full `config.toml` (including `[[mapping.projects]]`) and complete reference table

Closes #11

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All code blocks properly fenced
- [ ] No duplicate heading anchors
- [ ] Config example matches actual `config.py` dataclasses
- [ ] CLI commands match actual Click definitions in `cli.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote initialization flow as a clear 4-step interactive wizard (Credentials, OAuth, Sync settings, Project mappings)
  * Added comprehensive mapping management section with command examples
  * Expanded configuration reference with new authentication methods and sync options
  * Enhanced architecture and development documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->