### PR TITLE
fix: grant pull-requests write permission for code review comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
- The `claude-code-review.yml` workflow uses `--comment` to post review comments on PRs but only had `read` permission on `pull-requests`, causing comment posting to fail.
- Changed `pull-requests: read` → `pull-requests: write` to allow the action to post comments.

## Test plan
- [ ] Open a PR and verify the Claude Code Review workflow can post review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow configuration for the code review process.

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->