### PR TITLE
fix: display tilde-form paths in config show

### DIFF
--- a/src/tickticksync/cli.py
+++ b/src/tickticksync/cli.py
@@ -438,8 +438,8 @@ def daemon_start() -> None:
     d = Daemon(
         sync_engine=engine,
         queue=queue,
-        socket_path=cfg.sync.socket_path,
-        queue_path=cfg.sync.queue_path,
+        socket_path=cfg.sync.resolved_socket_path,
+        queue_path=cfg.sync.resolved_queue_path,
         poll_interval=cfg.sync.poll_interval,
     )
     asyncio.run(d.run())

--- a/src/tickticksync/config.py
+++ b/src/tickticksync/config.py
@@ -23,9 +23,13 @@ class SyncConfig:
     socket_path: str = "/tmp/tickticksync.sock"
     queue_path: str = "~/.local/share/tickticksync/hook_queue.json"
 
-    def __post_init__(self) -> None:
-        self.socket_path = str(Path(self.socket_path).expanduser())
-        self.queue_path = str(Path(self.queue_path).expanduser())
+    @property
+    def resolved_socket_path(self) -> str:
+        return str(Path(self.socket_path).expanduser())
+
+    @property
+    def resolved_queue_path(self) -> str:
+        return str(Path(self.queue_path).expanduser())
 
 
 @dataclass

--- a/src/tickticksync/hooks.py
+++ b/src/tickticksync/hooks.py
@@ -45,7 +45,7 @@ def _run_hook(skip_lines: int = 0) -> None:
         sys.stdin.readline()
     task = json.loads(sys.stdin.readline())
     cfg = load_config()
-    send_to_daemon(task, cfg.sync.socket_path, cfg.sync.queue_path)
+    send_to_daemon(task, cfg.sync.resolved_socket_path, cfg.sync.resolved_queue_path)
     print(json.dumps(task))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -779,6 +779,16 @@ def test_build_engine_passes_project_mappings():
 # config show / set
 # ---------------------------------------------------------------------------
 
+def test_config_show_displays_tilde_form_paths(runner, tmp_path):
+    """config show displays tilde-form paths, not expanded absolute paths."""
+    _, cfg = _make_cfg(tmp_path)
+    cfg.sync = SyncConfig(queue_path="~/.local/share/tickticksync/hook_queue.json")
+    with patch("tickticksync.cli.load_config", return_value=cfg):
+        result = runner.invoke(cli, ["config", "show"])
+    assert result.exit_code == 0
+    assert "~/.local/share/tickticksync/hook_queue.json" in result.output
+
+
 def test_config_show_displays_all_sections(runner, tmp_path):
     """config show pretty-prints all config sections."""
     _, cfg = _make_cfg(tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -381,3 +381,21 @@ def test_update_config_value_mapping_default_project_with_projects(tmp_path):
     assert cfg.mapping.default_project == "work"
     assert len(cfg.mapping.projects) == 1
     assert cfg.mapping.projects[0].ticktick == "Inbox"
+
+
+def test_sync_config_preserves_tilde_in_queue_path():
+    """SyncConfig stores the raw tilde string without eager expansion."""
+    sc = SyncConfig(queue_path="~/.local/share/tickticksync/hook_queue.json")
+    assert sc.queue_path == "~/.local/share/tickticksync/hook_queue.json"
+
+
+def test_sync_config_resolved_paths_expand_tilde():
+    """resolved_socket_path / resolved_queue_path expand ~ to absolute paths."""
+    sc = SyncConfig(
+        socket_path="~/sockets/test.sock",
+        queue_path="~/.local/share/tickticksync/hook_queue.json",
+    )
+    assert "~" not in sc.resolved_socket_path
+    assert sc.resolved_socket_path.endswith("/sockets/test.sock")
+    assert "~" not in sc.resolved_queue_path
+    assert sc.resolved_queue_path.endswith("/.local/share/tickticksync/hook_queue.json")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,6 +1,10 @@
+import io
 import json
 import socket
 from pathlib import Path
+from unittest.mock import patch
+
+from tickticksync.config import Config, TickTickConfig, SyncConfig
 from tickticksync.hooks import send_to_daemon, drain_queue
 
 
@@ -61,10 +65,6 @@ def test_drain_queue_noop_when_no_file(tmp_path):
 
 def test_run_hook_uses_resolved_paths(tmp_path, monkeypatch):
     """_run_hook expands tilde paths before passing to send_to_daemon."""
-    import io
-    from unittest.mock import patch
-    from tickticksync.config import Config, TickTickConfig, SyncConfig
-
     cfg = Config(
         ticktick=TickTickConfig(client_id="id", client_secret="sec"),
         sync=SyncConfig(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -62,7 +62,7 @@ def test_drain_queue_noop_when_no_file(tmp_path):
 def test_run_hook_uses_resolved_paths(tmp_path, monkeypatch):
     """_run_hook expands tilde paths before passing to send_to_daemon."""
     import io
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import patch
     from tickticksync.config import Config, TickTickConfig, SyncConfig
 
     cfg = Config(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -57,3 +57,33 @@ def test_drain_queue_sends_all_items_and_clears_file(tmp_path):
 def test_drain_queue_noop_when_no_file(tmp_path):
     queue_path = tmp_path / "queue.json"
     drain_queue(SOCKET_PATH, str(queue_path))  # must not raise
+
+
+def test_run_hook_uses_resolved_paths(tmp_path, monkeypatch):
+    """_run_hook expands tilde paths before passing to send_to_daemon."""
+    import io
+    from unittest.mock import patch, MagicMock
+    from tickticksync.config import Config, TickTickConfig, SyncConfig
+
+    cfg = Config(
+        ticktick=TickTickConfig(client_id="id", client_secret="sec"),
+        sync=SyncConfig(
+            socket_path="~/sockets/test.sock",
+            queue_path="~/.local/share/tickticksync/queue.json",
+        ),
+    )
+
+    task_json = '{"uuid": "u1", "description": "Test"}\n'
+    monkeypatch.setattr("sys.stdin", io.StringIO(task_json))
+
+    with (
+        patch("tickticksync.config.load_config", return_value=cfg),
+        patch("tickticksync.hooks.send_to_daemon") as mock_send,
+    ):
+        from tickticksync.hooks import _run_hook
+        with patch("builtins.print"):
+            _run_hook(skip_lines=0)
+
+    call_args = mock_send.call_args[0]
+    assert "~" not in call_args[1], f"socket_path not expanded: {call_args[1]}"
+    assert "~" not in call_args[2], f"queue_path not expanded: {call_args[2]}"


### PR DESCRIPTION
## Summary
- Remove eager `expanduser()` from `SyncConfig.__post_init__` so raw tilde-form paths are preserved in dataclass fields
- Add `resolved_socket_path` and `resolved_queue_path` properties that expand `~` on demand
- Update `hooks.py` and `cli.py` daemon startup to use resolved properties for filesystem operations

Closes #25

## Test plan
- [x] `config show` displays `~/.local/share/tickticksync/hook_queue.json` (tilde form) instead of expanded absolute path
- [x] `SyncConfig` preserves raw tilde strings in fields
- [x] `resolved_*` properties correctly expand `~` to absolute paths
- [x] `_run_hook` passes expanded paths to `send_to_daemon`
- [x] Full test suite passes (152 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling to properly expand tilde (~) paths throughout the application, ensuring paths are fully resolved before use by the daemon and hooks.

* **Tests**
  * Added tests verifying tilde path expansion and configuration display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->